### PR TITLE
Fixes audioseq crash when under 255 seqs

### DIFF
--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -482,10 +482,13 @@ void AudioLoad_AsyncLoadFont(s32 fontId, s32 arg1, s32 retData, OSMesgQueue* ret
 u8* AudioLoad_GetFontsForSequence(s32 seqId, u32* outNumFonts) {
     s32 index;
 
-    // if (seqId == 255)
-    //     return NULL;
+     if (seqId == NA_BGM_DISABLED)
+         return NULL;
 
     u16 newSeqId = SfxEditor_GetReplacementSeq(seqId);
+    if (!sequenceMap[newSeqId]){
+        return NULL;
+    }
     SequenceData sDat = ResourceMgr_LoadSeqByName(sequenceMap[newSeqId]);
 
     if (sDat.numFonts == 0)

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -4649,7 +4649,7 @@ void Audio_PlayFanfare(u16 seqId)
 
     sp26 = func_800FA0B4(SEQ_PLAYER_FANFARE);
     sp1C = func_800E5E84(sp26 & 0xFF, &sp20);
-    sp18 = func_800E5E84(seqId & 0xFF, &sp20);
+    sp18 = func_800E5E84(seqId, &sp20);
 	if (!sp1C || !sp18) {
 		// disable BGM, we're about to null deref!
 		D_8016B9F4 = 1;


### PR DESCRIPTION
When having no custom sequences loaded or, presumably, when the total number of sequences is below 255, the game will crash when attempting to play certain songs or fanfares. Reports include:
- Owl's theme
- Finish minigame
- Successfully generated seed
- Get item
- Get gold skulltula token
This should fix all those cases. It also includes a failsafe check for any possible attempts to play an invalid sequence id (`NA_BGM_DISABLED`), or an unmapped sequence id before attempting to load its corresponding resource, in case there are any other edge cases which might have slipped by this fix.